### PR TITLE
[WIP] New GitExtraGenerationBuilder builder

### DIFF
--- a/src/tito/builder/__init__.py
+++ b/src/tito/builder/__init__.py
@@ -5,6 +5,7 @@
 
 from tito.builder.main import \
     Builder, \
+    GitExtraGenerationBuilder, \
     NoTgzBuilder, \
     GemBuilder, \
     UpstreamBuilder, \


### PR DESCRIPTION
New builder to allow the inclusion of generated files that are not tracked by git on the final tar.gz

As the tito solution relies on "git archive" this was the only undisruptive solution I could find without keeping the generated files on git. 
Basically we are generating a new git reference on the top of the tag we are building and use it for the git archive, and afterwards we discard everything.

Each tito module can have 2 new files to configure this task:

setup.sh (example)
   `yarn install`

tito.gitgeneratedbuilder.include (example)
   `susemanager-nodejs-sdk-devel.tar.gz`

[WIP]
This still need some more tests and a better error handling, in case some command fail there is the risk that git gets on an inconsistent state. 

But before having a bullet proof solution would be nice to have more opinions about the direction of this solution.

@mcalmer 